### PR TITLE
GoTest SWF archives folder doesn't exist

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-	"SWF_URL": "https://josephanimate2021.github.io/gotest-swf-archives",
-	"STORE_URL": "https://josephanimate2021.github.io/store/50",
-	"CLIENT_URL": "https://josephanimate2021.github.io/static/477"
+	"SWF_URL": "https://josephanimate2021.github.io/animation/414827163ad4eb60",
+	"STORE_URL": "https://josephanimate2021.github.io/store/3a981f5cb2739137",
+	"CLIENT_URL": "https://josephanimate2021.github.io/static/ad44370a650793d9"
 }


### PR DESCRIPTION
Replaced with 2014 LVM compatible folders.